### PR TITLE
Remove the network adapter option from the installer

### DIFF
--- a/CloudbaseInitSetup/Actions/ConfFileActions.js
+++ b/CloudbaseInitSetup/Actions/ConfFileActions.js
@@ -27,7 +27,6 @@ function writeCloudbaseInitConfFileAction() {
         var userName = data[i++];
         var injectMetadataPassword = data[i++];
         var userGroups = data[i++];
-        var networkAdapterName = data[i++];
         var loggingSerialPortName = data[i++];
         var maasMetadataUrl = trim(data[i++]);
         var maasOAuthConsumerKey = trim(data[i++]);
@@ -49,7 +48,6 @@ function writeCloudbaseInitConfFileAction() {
             "username": trim(userName),
             "groups": trim(userGroups),
             "inject_user_password": checkBoxValueToBool(injectMetadataPassword),
-            "network_adapter": trim(networkAdapterName),
             "config_drive_raw_hhd": "true",
             "config_drive_cdrom": "true",
             "bsdtar_path": bsdtarPath,

--- a/CloudbaseInitSetup/Actions/ConfigDlgActions.js
+++ b/CloudbaseInitSetup/Actions/ConfigDlgActions.js
@@ -45,37 +45,10 @@ function setupLoggingSerialPortsComboBox() {
     view.Close();
 }
 
-function getNetworkAdapters() {
-    var property = "NETWORKADAPTERNAME";
-    var view = getComboBoxView(property);
-
-    deleteViewRecords(view);
-
-    var osVersion = getWindowsVersion()
-
-    var wmiSvc = getWmiCimV2Svc();
-
-    var query = "SELECT * FROM Win32_NetworkAdapter WHERE AdapterTypeId = 0 AND MACAddress IS NOT NULL"
-    if (osVersion[0] >= 6)
-        query += " AND PhysicalAdapter = True"
-
-    var networkAdapters = wmiSvc.ExecQuery(query)
-    var index = 1;
-    for (var e = new Enumerator(networkAdapters) ; !e.atEnd() ; e.moveNext()) {
-        // On XP / 2003 check the DeviceID to avoid including Miniport and other not relevant adapters
-        var networkAdapter = e.item();
-        if (osVersion[0] >= 6 || networkAdapter.PNPDeviceID.indexOf("PCI") == 0)
-            addComboBoxEntry(view, property, index++, networkAdapter.Name, networkAdapter.Name);
-    }
-
-    view.Close();
-}
-
 function initConfigDlgAction() {
     try {
         logMessage("Initializing ConfigDlg");
 
-        getNetworkAdapters();
         setupLoggingSerialPortsComboBox();
 
         return MsiActionStatus.Ok;

--- a/CloudbaseInitSetup/CustomActions.wxs
+++ b/CloudbaseInitSetup/CustomActions.wxs
@@ -51,7 +51,7 @@
                   Execute="deferred" Return="check" Impersonate="no" />
 
     <CustomAction Id="GenerateCloudbaseInitConfFile_Prop" Return="check" Property="GenerateCloudbaseInitConfFile"
-                  Value="[CLOUDBASEINITCONFFOLDER]|[BINFOLDER]|[LOGFOLDER]|[USERNAME]|[INJECTMETADATAPASSWORD]|[USERGROUPS]|[NETWORKADAPTERNAME]|[LOGGINGSERIALPORTNAME]|[MAAS_METADATA_URL]|[MAAS_OAUTH_CONSUMER_KEY]|[MAAS_OAUTH_CONSUMER_SECRET]|[MAAS_OAUTH_TOKEN_KEY]|[MAAS_OAUTH_TOKEN_SECRET]|[LOCALSCRIPTSFOLDER]" />
+                  Value="[CLOUDBASEINITCONFFOLDER]|[BINFOLDER]|[LOGFOLDER]|[USERNAME]|[INJECTMETADATAPASSWORD]|[USERGROUPS]|[LOGGINGSERIALPORTNAME]|[MAAS_METADATA_URL]|[MAAS_OAUTH_CONSUMER_KEY]|[MAAS_OAUTH_CONSUMER_SECRET]|[MAAS_OAUTH_TOKEN_KEY]|[MAAS_OAUTH_TOKEN_SECRET]|[LOCALSCRIPTSFOLDER]" />
     <CustomAction Id="GenerateCloudbaseInitConfFile"
               BinaryKey="ConfFileActions"
               JScriptCall="writeCloudbaseInitConfFileAction" Execute="deferred" Return="check" Impersonate="no" />

--- a/CloudbaseInitSetup/Dialogs/ConfigDlg.wxs
+++ b/CloudbaseInitSetup/Dialogs/ConfigDlg.wxs
@@ -23,15 +23,9 @@
           </ComboBox>
         </Control>
 
-        <Control Type="Text" Id="NetworkAdapterText" Width="146" Height="12" X="10" Y="158" Text="&amp;Network adapter to configure:">
+        <Control Type="Text" Id="LoggingSerialPortNameText" Width="146" Height="12" X="10" Y="158" Text="&amp;Serial port for logging:">
         </Control>
-        <Control Type="ComboBox" Property="NETWORKADAPTERNAME" Id="NetworkAdapterComboBox" Width="350" Height="16" X="10" Y="172" ComboList="yes">
-          <ComboBox Property="NETWORKADAPTERNAME" />
-        </Control>
-
-        <Control Type="Text" Id="LoggingSerialPortNameText" Width="146" Height="12" X="10" Y="198" Text="&amp;Serial port for logging:">
-        </Control>
-        <Control Type="ComboBox" Property="LOGGINGSERIALPORTNAME" Id="LoggingSerialPortNameComboBox" Width="100" Height="16" X="10" Y="212" ComboList="yes">
+        <Control Type="ComboBox" Property="LOGGINGSERIALPORTNAME" Id="LoggingSerialPortNameComboBox" Width="100" Height="16" X="10" Y="172" ComboList="yes">
           <ComboBox Property="LOGGINGSERIALPORTNAME" />
         </Control>
 


### PR DESCRIPTION
This option is redundant and it's currently unused, since the network config
plugin was refactored to not need it anymore.
