### PR TITLE
Install pip 7, in order to have support for environment markers

### DIFF
--- a/BuildAutomation/BuildCloudbaseInitSetup.ps1
+++ b/BuildAutomation/BuildCloudbaseInitSetup.ps1
@@ -51,7 +51,7 @@ try
     }
 
     ExecRetry { PipInstall "pbr>=1.5.0" }
-
+    ExecRetry { PipInstall "pip>=7.0.0" }
     if ($release)
     {
         ExecRetry { PipInstall "cloudbase-init==$release" }
@@ -60,10 +60,6 @@ try
     {
         ExecRetry { PullInstall "cloudbase-init" "https://github.com/stackforge/cloudbase-init.git" }
     }
-
-    # TODO: use a version of pip that supports requirements-windows
-    ExecRetry { PipInstall "wmi" }
-    ExecRetry { PipInstall "comtypes" }
 
     $release_dir = join-path $cloudbaseInitInstallerDir "CloudbaseInitSetup\bin\Release\$platform"
     $bin_dir = join-path $cloudbaseInitInstallerDir "CloudbaseInitSetup\Binaries\$platform"


### PR DESCRIPTION
Environment markers represents a condition about the current execution environment, used to specify which dependency can be installed according to the aforementioned conditions.
They were added in PEP 426 (https://www.python.org/dev/peps/pep-0426/), but moved into a separate informational PEP later on (PEP 496).
At the same time, we're removing manual installation of comtypes and wmi, which should be handled automatically by environment markers found in requirements.txt.
