### PR TITLE
Set sysprep to reboot on success and reboot-retry on failed execution…

### DIFF
--- a/CloudbaseInitSetup/Unattend.xml
+++ b/CloudbaseInitSetup/Unattend.xml
@@ -21,9 +21,9 @@
       <RunSynchronous>
         <RunSynchronousCommand wcm:action="add">
           <Order>1</Order>
-          <Path>"%INSTALLDIR%Python\Scripts\cloudbase-init.exe" --config-file "%CLOUDBASEINITCONFFOLDER%cloudbase-init-unattend.conf"</Path>
+          <Path>cmd.exe /c ""%INSTALLDIR%Python\Scripts\cloudbase-init.exe" --config-file "%CLOUDBASEINITCONFFOLDER%cloudbase-init-unattend.conf" && exit 1 || exit 2"</Path>
           <Description>Run Cloudbase-Init to set the hostname</Description>
-          <WillReboot>Always</WillReboot>
+          <WillReboot>OnRequest</WillReboot>
         </RunSynchronousCommand>
       </RunSynchronous>
     </component>


### PR DESCRIPTION
… of cloudbase-init

If the password reset for the cloudbase-init service user fails,
specialize command issues a retry thorugh the exit code 2.

If the specialize command exits with code 1, just a normal reboot
will be perfomed.

Sysprep documentation:
https://technet.microsoft.com/en-us/library/cc766514(v=ws.10).aspx
