### PR TITLE
service: cbs-init start after services it depends on

### DIFF
--- a/CloudbaseInitSetup/Product.wxs
+++ b/CloudbaseInitSetup/Product.wxs
@@ -222,7 +222,9 @@
                Password="[GENERATED_PASSWORD]"
                ErrorControl="ignore"
                Interactive="no">
-        <ServiceDependency Id="Winmgmt" />
+        <ServiceDependency Id="winmgmt" />
+        <ServiceDependency Id="nsi" />
+        <ServiceDependency Id="profsvc" />
         <!--
         <ServiceConfig DelayedAutoStart="yes" OnInstall="yes" />
         -->


### PR DESCRIPTION
Cloudbase-Init Windows Service should start after:

  * Network Store Interface Service
  * User Profile Service
  * Windows Management Instrumentation

These services are required for critical parts of the cloudbase-init workflow.

Although Cloudbase-Init has retries for most of the issues that appear if one of the above service is not yet started, it is preferable to limit the issues that may appear.