### PR TITLE
python: add installer option

### DIFF
--- a/.github/workflows/build_test_cbsinit.yml
+++ b/.github/workflows/build_test_cbsinit.yml
@@ -29,7 +29,8 @@ jobs:
             -VCVars "automatic" ^
             -VSRedistDir "''" ^
             -CloudbaseInitRepoUrl ${{ matrix.cbsinit_repo }} ^
-            -CloudbaseInitRepoBranch ${{ matrix.cbsinit_branch }}
+            -CloudbaseInitRepoBranch ${{ matrix.cbsinit_branch }} ^
+            -PythonMsiChecksum "not a real checksum"
     - uses: actions/upload-artifact@v7
       with:
         name: "CloudbaseInit_${{ matrix.platform }}_${{ matrix.os }}_MSI_${{ matrix.cbsinit_branch }}"

--- a/.github/workflows/build_test_cbsinit.yml
+++ b/.github/workflows/build_test_cbsinit.yml
@@ -30,7 +30,7 @@ jobs:
             -VSRedistDir "''" ^
             -CloudbaseInitRepoUrl ${{ matrix.cbsinit_repo }} ^
             -CloudbaseInitRepoBranch ${{ matrix.cbsinit_branch }} ^
-            -PythonMsiChecksum "not a real checksum"
+            -PythonMsiChecksum "C10234D0D9BD89F6F6DD55BAE28EDE0F97EE0DF4"
     - uses: actions/upload-artifact@v7
       with:
         name: "CloudbaseInit_${{ matrix.platform }}_${{ matrix.os }}_MSI_${{ matrix.cbsinit_branch }}"

--- a/.github/workflows/build_test_cbsinit.yml
+++ b/.github/workflows/build_test_cbsinit.yml
@@ -30,7 +30,7 @@ jobs:
             -VSRedistDir "''" ^
             -CloudbaseInitRepoUrl ${{ matrix.cbsinit_repo }} ^
             -CloudbaseInitRepoBranch ${{ matrix.cbsinit_branch }} ^
-            -InstallOfficialPythonMsi:$true ^
+            -InstallOfficialPythonMsi:$false ^
             -OfficialPythonMsiChecksum "C10234D0D9BD89F6F6DD55BAE28EDE0F97EE0DF4"
     - uses: actions/upload-artifact@v7
       with:

--- a/.github/workflows/build_test_cbsinit.yml
+++ b/.github/workflows/build_test_cbsinit.yml
@@ -9,6 +9,7 @@ jobs:
       max-parallel: 100
       matrix:
         os: ['windows-2022']
+        download_official_python_msi: ["true", "false"]
         cbsinit_repo: ['https://github.com/cloudbase/cloudbase-init']
         cbsinit_branch: ['master']
         python_version: ['3.14_4']
@@ -30,7 +31,7 @@ jobs:
             -VSRedistDir "''" ^
             -CloudbaseInitRepoUrl ${{ matrix.cbsinit_repo }} ^
             -CloudbaseInitRepoBranch ${{ matrix.cbsinit_branch }} ^
-            -InstallOfficialPythonMsi:$false ^
+            -InstallOfficialPythonMsi:$${{ matrix.download_official_python_msi }} ^
             -OfficialPythonMsiChecksum "C10234D0D9BD89F6F6DD55BAE28EDE0F97EE0DF4"
     - uses: actions/upload-artifact@v7
       with:

--- a/.github/workflows/build_test_cbsinit.yml
+++ b/.github/workflows/build_test_cbsinit.yml
@@ -30,7 +30,8 @@ jobs:
             -VSRedistDir "''" ^
             -CloudbaseInitRepoUrl ${{ matrix.cbsinit_repo }} ^
             -CloudbaseInitRepoBranch ${{ matrix.cbsinit_branch }} ^
-            -PythonMsiChecksum "C10234D0D9BD89F6F6DD55BAE28EDE0F97EE0DF4"
+            -InstallOfficialPythonMsi:$true ^
+            -OfficialPythonMsiChecksum "C10234D0D9BD89F6F6DD55BAE28EDE0F97EE0DF4"
     - uses: actions/upload-artifact@v7
       with:
         name: "CloudbaseInit_${{ matrix.platform }}_${{ matrix.os }}_MSI_${{ matrix.cbsinit_branch }}"

--- a/BuildAutomation/BuildCloudbaseInitSetup.ps1
+++ b/BuildAutomation/BuildCloudbaseInitSetup.ps1
@@ -10,7 +10,8 @@ Param(
   [switch]$ClonePullInstallerRepo = $true,
   [string]$VSRedistDir = "${ENV:ProgramFiles(x86)}\Common Files\Merge Modules",
   [string]$SignTimestampUrl = "http://timestamp.digicert.com?alg=sha256",
-  [string]$VCVars="2019"
+  [string]$VCVars="2019",
+  [string]$PythonMsiChecksum = $null
 )
 
 $ErrorActionPreference = "Stop"
@@ -76,6 +77,10 @@ try
     $ENV:PATH = "$python_dir\;$python_dir\scripts;$ENV:PATH"
 
     $python_template_dir = join-path $cloudbaseInitInstallerDir "Python$($pythonversion.replace('.', ''))_${platform}_Template"
+
+    if ($PythonMsiChecksum) {
+        DownloadInstall-PythonMsi $platform $python_template_dir $pythonversion $PythonMsiChecksum
+    }
 
     CheckCopyDir $python_template_dir $python_dir
 

--- a/BuildAutomation/BuildCloudbaseInitSetup.ps1
+++ b/BuildAutomation/BuildCloudbaseInitSetup.ps1
@@ -79,6 +79,7 @@ try
     $python_template_dir = join-path $cloudbaseInitInstallerDir "Python$($pythonversion.replace('.', ''))_${platform}_Template"
 
     if ($PythonMsiChecksum) {
+        Remove-Item -Recurse -Force $python_template_dir -ErrorAction SilentlyContinue
         DownloadInstall-PythonMsi $platform $python_template_dir $pythonversion $PythonMsiChecksum
     }
 

--- a/BuildAutomation/BuildCloudbaseInitSetup.ps1
+++ b/BuildAutomation/BuildCloudbaseInitSetup.ps1
@@ -10,8 +10,9 @@ Param(
   [switch]$ClonePullInstallerRepo = $true,
   [string]$VSRedistDir = "${ENV:ProgramFiles(x86)}\Common Files\Merge Modules",
   [string]$SignTimestampUrl = "http://timestamp.digicert.com?alg=sha256",
-  [string]$VCVars="2019",
-  [string]$PythonMsiChecksum = $null
+  [string]$VCVars = "2019",
+  [switch]$InstallOfficialPythonMsi = $false,
+  [string]$OfficialPythonMsiChecksum = "C10234D0D9BD89F6F6DD55BAE28EDE0F97EE0DF4"
 )
 
 $ErrorActionPreference = "Stop"
@@ -78,9 +79,12 @@ try
 
     $python_template_dir = join-path $cloudbaseInitInstallerDir "Python$($pythonversion.replace('.', ''))_${platform}_Template"
 
-    if ($PythonMsiChecksum) {
+    if ($InstallOfficialPythonMsi) {
+        if (!$OfficialPythonMsiChecksum) {
+            throw "Please set a OfficialPythonMsiChecksum parameter value."
+        }
         Remove-Item -Recurse -Force $python_template_dir -ErrorAction SilentlyContinue
-        DownloadInstall-PythonMsi $platform $python_template_dir $pythonversion $PythonMsiChecksum
+        DownloadInstall-PythonMsi $platform $python_template_dir $pythonversion $OfficialPythonMsiChecksum
     }
 
     CheckCopyDir $python_template_dir $python_dir


### PR DESCRIPTION
If MSI checksum is set, then the builder will download the Python installer, install Python at a temp location, then move the folder to the known location. At the end, the Python package will be uninstalled.