### PR TITLE
python: remove the pycs and pycaches

### DIFF
--- a/.github/workflows/build_test_cbsinit.yml
+++ b/.github/workflows/build_test_cbsinit.yml
@@ -9,7 +9,8 @@ jobs:
       max-parallel: 100
       matrix:
         os: ['windows-2022']
-        download_official_python_msi: ["true", "false"]
+        download_official_python_msi: ["true"]
+        remove_python_pycs: ["true"]
         cbsinit_repo: ['https://github.com/cloudbase/cloudbase-init']
         cbsinit_branch: ['master']
         python_version: ['3.14_4']
@@ -32,10 +33,11 @@ jobs:
             -CloudbaseInitRepoUrl ${{ matrix.cbsinit_repo }} ^
             -CloudbaseInitRepoBranch ${{ matrix.cbsinit_branch }} ^
             -InstallOfficialPythonMsi:$${{ matrix.download_official_python_msi }} ^
-            -OfficialPythonMsiChecksum "C10234D0D9BD89F6F6DD55BAE28EDE0F97EE0DF4"
+            -OfficialPythonMsiChecksum "C10234D0D9BD89F6F6DD55BAE28EDE0F97EE0DF4" ^
+            -RemovePythonPycs:$${{ matrix.remove_python_pycs }}
     - uses: actions/upload-artifact@v7
       with:
-        name: "CloudbaseInit_${{ matrix.platform }}_${{ matrix.os }}_MSI_${{ matrix.cbsinit_branch }}"
+        name: "CloudbaseInit_platform-${{ matrix.platform }}_build-env-os-${{ matrix.os }}_download-official-msi-${{ matrix.download_official_python_msi }}_remove-pycs-${{ matrix.remove_python_pycs }}_cbs-init-branch-${{ matrix.cbsinit_branch }}_MSI"
         path: 'CloudbaseInitSetup/bin/release/${{ matrix.platform }}/CloudbaseInitSetup.msi'
     - name: Download external dependencies
       shell: powershell

--- a/BuildAutomation/BuildCloudbaseInitSetup.ps1
+++ b/BuildAutomation/BuildCloudbaseInitSetup.ps1
@@ -12,7 +12,8 @@ Param(
   [string]$SignTimestampUrl = "http://timestamp.digicert.com?alg=sha256",
   [string]$VCVars = "2019",
   [switch]$InstallOfficialPythonMsi = $false,
-  [string]$OfficialPythonMsiChecksum = "C10234D0D9BD89F6F6DD55BAE28EDE0F97EE0DF4"
+  [string]$OfficialPythonMsiChecksum = "C10234D0D9BD89F6F6DD55BAE28EDE0F97EE0DF4",
+  [switch]$RemovePythonPycs = $false
 )
 
 $ErrorActionPreference = "Stop"
@@ -128,6 +129,12 @@ try
         ExecRetry { PullInstall "cloudbase-init" $CloudbaseInitRepoUrl $CloudbaseInitRepoBranch }
     }
 
+    if ($RemovePythonPycs) {
+        pushd $python_dir
+            Get-ChildItem -Path .\ -Recurse -Include *__pycache__ | foreach ($_) { Remove-Item $_.FullName -Force -Recurse}
+            Get-ChildItem -Path .\ -Recurse -Include *.pyc | foreach ($_) { Remove-Item $_.FullName -Force -Recurse}
+        popd
+    }
     $release_dir = join-path $cloudbaseInitInstallerDir "CloudbaseInitSetup\bin\Release\$platform"
     $bin_dir = join-path $cloudbaseInitInstallerDir "CloudbaseInitSetup\Binaries\$platform"
 


### PR DESCRIPTION
In the Python folder, as the same Python is used also for building cloudbase-init, there are alot of pycs / __pycache__ files and folders, which are bulking up the MSI size.

The github actions runs show a rather counter-intuitive comparison on the run times: the cloudbase-init packaged without the pycs runs faster than the one with packaged pycs. This behaviour makes sense if the Python interpreter actually spends more time in checking the existing pycs, then replacing them with newer ones maybe.

In any case, the end result is beneficial from two perspectives: smaller MSI size 49.3 MB vs 60.4 MB and almost one minute faster run.