### PR TITLE
Add support for embeded Python

### DIFF
--- a/.github/workflows/build_test_cbsinit.yml
+++ b/.github/workflows/build_test_cbsinit.yml
@@ -14,7 +14,7 @@ jobs:
         install_with_pymanager: ["true"]
         cbsinit_repo: ['https://github.com/cloudbase/cloudbase-init']
         cbsinit_branch: ['master']
-        python_version: ['3.11_9']
+        python_version: ['3.14_4']
         platform: ['x64']
         cloud: [openstack] 
 

--- a/.github/workflows/build_test_cbsinit.yml
+++ b/.github/workflows/build_test_cbsinit.yml
@@ -101,6 +101,7 @@ jobs:
             }
         }
         & $pythonPath -m pip install pip-audit
+        & $pythonPath -m pip install venv
         $pipAuditLogs = & $pipAuditPath
         Write-Output "$pipAuditLogs"
         if ($LASTEXITCODE) {

--- a/.github/workflows/build_test_cbsinit.yml
+++ b/.github/workflows/build_test_cbsinit.yml
@@ -101,8 +101,7 @@ jobs:
             }
         }
         & $pythonPath -m pip install pip-audit
-        & $pythonPath -m pip install venv
-        $pipAuditLogs = & $pipAuditPath
+        $pipAuditLogs = & $pipAuditPath --user
         Write-Output "$pipAuditLogs"
         if ($LASTEXITCODE) {
           throw "pip audit failed"

--- a/.github/workflows/build_test_cbsinit.yml
+++ b/.github/workflows/build_test_cbsinit.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         os: ['windows-2022']
         download_official_python_msi: ["true"]
-        remove_python_pycs: ["true"]
+        remove_python_pycs: ["false"]
         install_with_pymanager: ["true"]
         cbsinit_repo: ['https://github.com/cloudbase/cloudbase-init']
         cbsinit_branch: ['master']

--- a/.github/workflows/build_test_cbsinit.yml
+++ b/.github/workflows/build_test_cbsinit.yml
@@ -14,7 +14,7 @@ jobs:
         install_with_pymanager: ["true"]
         cbsinit_repo: ['https://github.com/cloudbase/cloudbase-init']
         cbsinit_branch: ['master']
-        python_version: ['3.14_4']
+        python_version: ['3.11_9']
         platform: ['x64']
         cloud: [openstack] 
 

--- a/BuildAutomation/BuildCloudbaseInitSetup.ps1
+++ b/BuildAutomation/BuildCloudbaseInitSetup.ps1
@@ -115,6 +115,11 @@ try
     }
 
     ExecRetry { PipInstall "pip" -update $true }
+    # When using embed Python, pbr needs to be reinstalled so that the project builds
+    # Warning received: UserWarning: Unknown distribution option: 'pbr'
+    # pbr is already installed but most likely this is a problem with knowing where it is,
+    # and reinstalling fixing the issue
+    ExecRetry { PipInstall "pbr" -update $true }
     ExecRetry { PipInstall "wheel" -update $true }
     ExecRetry { PipInstall "setuptools" -update $true }
 

--- a/BuildAutomation/BuildCloudbaseInitSetup.ps1
+++ b/BuildAutomation/BuildCloudbaseInitSetup.ps1
@@ -97,6 +97,15 @@ try
 
     CheckCopyDir $python_template_dir $python_dir
 
+    $pythonGetPipUrl = "https://bootstrap.pypa.io/get-pip.py"
+    $pythonGetPipPath = Join-Path (Resolve-Path "${python_dir}/..").Path "/get-pip.py"
+    ExecRetry { DownloadFile $pythonGetPipUrl $pythonGetPipPath }
+
+    & python.exe "${pythonGetPipPath}"
+    if ($LASTEXITCODE) {
+        throw "Failed to install pip in directory: ${python_dir}"
+    }
+
     # Make sure that we don't have temp files from a previous build
     $python_build_path = "$ENV:LOCALAPPDATA\Temp\pip_build_$ENV:USERNAME"
     if (Test-Path $python_build_path) {

--- a/BuildAutomation/BuildCloudbaseInitSetup.ps1
+++ b/BuildAutomation/BuildCloudbaseInitSetup.ps1
@@ -106,6 +106,8 @@ try
         throw "Failed to install pip in directory: ${python_dir}"
     }
 
+    python.exe -m pip install pip --upgrade
+
     # Make sure that we don't have temp files from a previous build
     $python_build_path = "$ENV:LOCALAPPDATA\Temp\pip_build_$ENV:USERNAME"
     if (Test-Path $python_build_path) {

--- a/BuildAutomation/BuildCloudbaseInitSetup.ps1
+++ b/BuildAutomation/BuildCloudbaseInitSetup.ps1
@@ -106,10 +106,8 @@ try
         throw "Failed to install pip in directory: ${python_dir}"
     }
 
-    python.exe -m pip install pip --upgrade
-    python.exe -m pip install wheel --upgrade
-    python.exe -m pip install setuptools --upgrade
-
+    Out-File -Append -InputObject "Lib\site-packages" -Encoding ascii $python_dir\python*._pth
+    
     # Make sure that we don't have temp files from a previous build
     $python_build_path = "$ENV:LOCALAPPDATA\Temp\pip_build_$ENV:USERNAME"
     if (Test-Path $python_build_path) {

--- a/BuildAutomation/BuildCloudbaseInitSetup.ps1
+++ b/BuildAutomation/BuildCloudbaseInitSetup.ps1
@@ -105,8 +105,6 @@ try
     if ($LASTEXITCODE) {
         throw "Failed to install pip in directory: ${python_dir}"
     }
-
-    Out-File -Append -InputObject "Lib\site-packages" -Encoding ascii $python_dir\python*._pth
     
     # Make sure that we don't have temp files from a previous build
     $python_build_path = "$ENV:LOCALAPPDATA\Temp\pip_build_$ENV:USERNAME"

--- a/BuildAutomation/BuildCloudbaseInitSetup.ps1
+++ b/BuildAutomation/BuildCloudbaseInitSetup.ps1
@@ -107,6 +107,8 @@ try
     }
 
     python.exe -m pip install pip --upgrade
+    python.exe -m pip install wheel --upgrade
+    python.exe -m pip install setuptools --upgrade
 
     # Make sure that we don't have temp files from a previous build
     $python_build_path = "$ENV:LOCALAPPDATA\Temp\pip_build_$ENV:USERNAME"

--- a/BuildAutomation/BuildUtils.ps1
+++ b/BuildAutomation/BuildUtils.ps1
@@ -510,6 +510,8 @@ function DownloadInstall-PythonUsingPyManager($platform, $python_template_dir, $
     popd
 
     Move-Item "cpython/Include" "$python_template_dir/include"
+    ExecRetry { DownloadFile "https://raw.githubusercontent.com/python/cpython/refs/tags/v${gitTag}/PC/pyconfig.h" "${python_template_dir}/include/pyconfig.h" }
+
     Get-ChildItem "$python_template_dir/include"
     Remove-Item -Force -Recurse "cpython"
 

--- a/BuildAutomation/BuildUtils.ps1
+++ b/BuildAutomation/BuildUtils.ps1
@@ -499,6 +499,9 @@ function DownloadInstall-PythonUsingPyManager($platform, $python_template_dir, $
         throw "Failed to run python in directory: ${python_template_dir}"
     }
 
+    Out-File -Append -InputObject "Lib\site-packages" -Encoding ascii $python_template_dir\python*._pth
+
+    # fix Cannot open include file: 'pyconfig.h'
     $gitTag = $pythonVersion.replace("_",".")
     git clone --no-checkout --depth=1 --filter=tree:0 https://github.com/python/cpython --branch "v${gitTag}"
     pushd cpython
@@ -506,7 +509,8 @@ function DownloadInstall-PythonUsingPyManager($platform, $python_template_dir, $
         git checkout
     popd
 
-    Move-Item "cpython/Include" "$python_template_dir/Include"
+    Move-Item "cpython/Include" "$python_template_dir/include"
+    Get-ChildItem "$python_template_dir/include"
     Remove-Item -Force -Recurse "cpython"
 
     Remove-Item -Force -Recurse "$python_template_dir/DLLs/_tkinter.pyd" -ErrorAction SilentlyContinue

--- a/BuildAutomation/BuildUtils.ps1
+++ b/BuildAutomation/BuildUtils.ps1
@@ -512,6 +512,13 @@ function DownloadInstall-PythonUsingPyManager($platform, $python_template_dir, $
     Move-Item $python_template_dir_full/include $python_template_dir/
     Move-Item $python_template_dir_full/libs $python_template_dir/
 
+    mkdir $python_template_dir\Lib\site-packages
+
+    Out-File -Append -InputObject "win32" -Encoding ascii "$python_template_dir\Lib\site-packages\pywin32.pth"
+    Out-File -Append -InputObject "win32\lib" -Encoding ascii "$python_template_dir\Lib\site-packages\pywin32.pth"
+    Out-File -Append -InputObject "Pythonwin" -Encoding ascii "$python_template_dir\Lib\site-packages\pywin32.pth"
+    Out-File -Append -InputObject "import pywin32_bootstrap" -Encoding ascii "$python_template_dir\Lib\site-packages\pywin32.pth"
+
     Remove-Item -Force -Recurse "$python_template_dir_full" -ErrorAction SilentlyContinue
 
     Remove-Item -Force -Recurse "$python_template_dir/DLLs/_tkinter.pyd" -ErrorAction SilentlyContinue

--- a/BuildAutomation/BuildUtils.ps1
+++ b/BuildAutomation/BuildUtils.ps1
@@ -509,8 +509,8 @@ function DownloadInstall-PythonUsingPyManager($platform, $python_template_dir, $
         throw "Failed to install python in directory: ${python_template_dir_full}"
     }
 
-    Move-Item $python_template_dir_full/include python_template_dir/
-    Move-Item $python_template_dir_full/libs python_template_dir/
+    Move-Item $python_template_dir_full/include $python_template_dir/
+    Move-Item $python_template_dir_full/libs $python_template_dir/
 
     Remove-Item -Force -Recurse "$python_template_dir_full" -ErrorAction SilentlyContinue
 

--- a/BuildAutomation/BuildUtils.ps1
+++ b/BuildAutomation/BuildUtils.ps1
@@ -499,6 +499,15 @@ function DownloadInstall-PythonUsingPyManager($platform, $python_template_dir, $
         throw "Failed to run python in directory: ${python_template_dir}"
     }
 
+    $pythonGetPipUrl = "https://bootstrap.pypa.io/get-pip.py"
+    $pythonGetPipPath = Join-Path (Resolve-Path "${python_template_dir}/..").Path "/get-pip.py"
+    ExecRetry { DownloadFile $pythonGetPipUrl $pythonGetPipPath }
+
+    & "$python_template_dir/python.exe" "${pythonGetPipPath}"
+    if ($LASTEXITCODE) {
+        throw "Failed to install pip in directory: ${python_template_dir}"
+    }
+
     Remove-Item -Force -Recurse "$python_template_dir/DLLs/_tkinter.pyd" -ErrorAction SilentlyContinue
     Remove-Item -Force -Recurse "$python_template_dir/DLLs/tcl*.dll" -ErrorAction SilentlyContinue
     Remove-Item -Force -Recurse "$python_template_dir/DLLs/tk*.dll" -ErrorAction SilentlyContinue

--- a/BuildAutomation/BuildUtils.ps1
+++ b/BuildAutomation/BuildUtils.ps1
@@ -499,6 +499,16 @@ function DownloadInstall-PythonUsingPyManager($platform, $python_template_dir, $
         throw "Failed to run python in directory: ${python_template_dir}"
     }
 
+    $gitTag = $pythonVersion.replace("_",".")
+    git clone --no-checkout --depth=1 --filter=tree:0 https://github.com/python/cpython --branch "v${gitTag}"
+    pushd cpython
+        git sparse-checkout set --no-cone /Include
+        git checkout
+    popd
+
+    Move-Item "cpython/Include" "$python_template_dir/Include"
+    Remove-Item -Force -Recurse "cpython"
+
     Remove-Item -Force -Recurse "$python_template_dir/DLLs/_tkinter.pyd" -ErrorAction SilentlyContinue
     Remove-Item -Force -Recurse "$python_template_dir/DLLs/tcl*.dll" -ErrorAction SilentlyContinue
     Remove-Item -Force -Recurse "$python_template_dir/DLLs/tk*.dll" -ErrorAction SilentlyContinue

--- a/BuildAutomation/BuildUtils.ps1
+++ b/BuildAutomation/BuildUtils.ps1
@@ -519,6 +519,10 @@ function DownloadInstall-PythonUsingPyManager($platform, $python_template_dir, $
     Out-File -Append -InputObject "Pythonwin" -Encoding ascii "$python_template_dir\Lib\site-packages\pywin32.pth"
     Out-File -Append -InputObject "import pywin32_bootstrap" -Encoding ascii "$python_template_dir\Lib\site-packages\pywin32.pth"
 
+    Out-File -Append -InputObject "Lib\site-packages\win32" -Encoding ascii $python_template_dir\python*._pth
+    Out-File -Append -InputObject "Lib\site-packages\win32\lib" -Encoding ascii $python_template_dir\python*._pth
+    Out-File -Append -InputObject "Lib\site-packages\Pythonwin" -Encoding ascii $python_template_dir\python*._pth
+
     Remove-Item -Force -Recurse "$python_template_dir_full" -ErrorAction SilentlyContinue
 
     Remove-Item -Force -Recurse "$python_template_dir/DLLs/_tkinter.pyd" -ErrorAction SilentlyContinue

--- a/BuildAutomation/BuildUtils.ps1
+++ b/BuildAutomation/BuildUtils.ps1
@@ -500,6 +500,7 @@ function DownloadInstall-PythonUsingPyManager($platform, $python_template_dir, $
     }
 
     Out-File -Append -InputObject "Lib\site-packages" -Encoding ascii $python_template_dir\python*._pth
+    Out-File -Append -InputObject "libs" -Encoding ascii $python_template_dir\python*._pth
 
     # fix Cannot open include file: 'pyconfig.h'
     $gitTag = $pythonVersion.replace("_",".")

--- a/BuildAutomation/BuildUtils.ps1
+++ b/BuildAutomation/BuildUtils.ps1
@@ -502,19 +502,17 @@ function DownloadInstall-PythonUsingPyManager($platform, $python_template_dir, $
     Out-File -Append -InputObject "Lib\site-packages" -Encoding ascii $python_template_dir\python*._pth
     Out-File -Append -InputObject "libs" -Encoding ascii $python_template_dir\python*._pth
 
-    # fix Cannot open include file: 'pyconfig.h'
-    $gitTag = $pythonVersion.replace("_",".")
-    git clone --no-checkout --depth=1 --filter=tree:0 https://github.com/python/cpython --branch "v${gitTag}"
-    pushd cpython
-        git sparse-checkout set --no-cone /Include
-        git checkout
-    popd
+    $python_template_dir_full = $python_template_dir + "_full"
+    $pythonVersionEscaped = $pythonVersion.replace("_",".") + $platformSuffix
+    pymanager.exe install --target=$python_template_dir_full --force --update $pythonVersionEscaped
+    if ($LASTEXITCODE) {
+        throw "Failed to install python in directory: ${python_template_dir_full}"
+    }
 
-    Move-Item "cpython/Include" "$python_template_dir/include"
-    ExecRetry { DownloadFile "https://raw.githubusercontent.com/python/cpython/refs/tags/v${gitTag}/PC/pyconfig.h" "${python_template_dir}/include/pyconfig.h" }
+    Move-Item $python_template_dir_full/include python_template_dir/
+    Move-Item $python_template_dir_full/libs python_template_dir/
 
-    Get-ChildItem "$python_template_dir/include"
-    Remove-Item -Force -Recurse "cpython"
+    Remove-Item -Force -Recurse "$python_template_dir_full" -ErrorAction SilentlyContinue
 
     Remove-Item -Force -Recurse "$python_template_dir/DLLs/_tkinter.pyd" -ErrorAction SilentlyContinue
     Remove-Item -Force -Recurse "$python_template_dir/DLLs/tcl*.dll" -ErrorAction SilentlyContinue

--- a/BuildAutomation/BuildUtils.ps1
+++ b/BuildAutomation/BuildUtils.ps1
@@ -484,7 +484,7 @@ function DownloadInstall-PythonUsingPyManager($platform, $python_template_dir, $
         throw "$python_template_dir folder already exists"
     }
 
-    $pythonVersionEscaped = $pythonVersion.replace("_",".") + $platformSuffix
+    $pythonVersionEscaped = "PythonEmbed\" + $pythonVersion.replace("_",".") + $platformSuffix
     pymanager.exe install --target=$python_template_dir --force --update $pythonVersionEscaped
     if ($LASTEXITCODE) {
         throw "Failed to install python in directory: ${python_template_dir}"
@@ -499,12 +499,12 @@ function DownloadInstall-PythonUsingPyManager($platform, $python_template_dir, $
         throw "Failed to run python in directory: ${python_template_dir}"
     }
 
-    Remove-Item -Force -Recurse "$python_template_dir/DLLs/_tkinter.pyd"
-    Remove-Item -Force -Recurse "$python_template_dir/DLLs/tcl*.dll"
-    Remove-Item -Force -Recurse "$python_template_dir/DLLs/tk*.dll"
-    Remove-Item -Force -Recurse "$python_template_dir/Doc"
-    Remove-Item -Force -Recurse "$python_template_dir/Lib/tkinter"
-    Remove-Item -Force -Recurse "$python_template_dir/Lib/turtle.py"
-    Remove-Item -Force -Recurse "$python_template_dir/Lib/turtledemo"
-    Remove-Item -Force -Recurse "$python_template_dir/tcl"
+    Remove-Item -Force -Recurse "$python_template_dir/DLLs/_tkinter.pyd" -ErrorAction SilentlyContinue
+    Remove-Item -Force -Recurse "$python_template_dir/DLLs/tcl*.dll" -ErrorAction SilentlyContinue
+    Remove-Item -Force -Recurse "$python_template_dir/DLLs/tk*.dll" -ErrorAction SilentlyContinue
+    Remove-Item -Force -Recurse "$python_template_dir/Doc" -ErrorAction SilentlyContinue
+    Remove-Item -Force -Recurse "$python_template_dir/Lib/tkinter" -ErrorAction SilentlyContinue
+    Remove-Item -Force -Recurse "$python_template_dir/Lib/turtle.py" -ErrorAction SilentlyContinue
+    Remove-Item -Force -Recurse "$python_template_dir/Lib/turtledemo" -ErrorAction SilentlyContinue
+    Remove-Item -Force -Recurse "$python_template_dir/tcl" -ErrorAction SilentlyContinue
 }

--- a/BuildAutomation/BuildUtils.ps1
+++ b/BuildAutomation/BuildUtils.ps1
@@ -499,15 +499,6 @@ function DownloadInstall-PythonUsingPyManager($platform, $python_template_dir, $
         throw "Failed to run python in directory: ${python_template_dir}"
     }
 
-    $pythonGetPipUrl = "https://bootstrap.pypa.io/get-pip.py"
-    $pythonGetPipPath = Join-Path (Resolve-Path "${python_template_dir}/..").Path "/get-pip.py"
-    ExecRetry { DownloadFile $pythonGetPipUrl $pythonGetPipPath }
-
-    & "$python_template_dir/python.exe" "${pythonGetPipPath}"
-    if ($LASTEXITCODE) {
-        throw "Failed to install pip in directory: ${python_template_dir}"
-    }
-
     Remove-Item -Force -Recurse "$python_template_dir/DLLs/_tkinter.pyd" -ErrorAction SilentlyContinue
     Remove-Item -Force -Recurse "$python_template_dir/DLLs/tcl*.dll" -ErrorAction SilentlyContinue
     Remove-Item -Force -Recurse "$python_template_dir/DLLs/tk*.dll" -ErrorAction SilentlyContinue


### PR DESCRIPTION
What works: everything cloudbase-init related.

Hacks required:

  * Borrow folders from the full install - > "Include" and "libs" for the PyMI build.
  * Configure .pth file to have the site-packages and pywin32 required module paths

What does not work: pip-audit from the github actions as the embeded Python does not have the virtualenv (venv) package as a core package from cpython.

Previous attempt: https://github.com/cloudbase/cloudbase-init-installer/pull/39